### PR TITLE
Specify Import-Module command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository creates pull requests to push a GitHub Actions workflow to a col
 2. Open powershell and navigate to the directory you cloned this into 
 3. Rename the file called `.env-example` to `.env` and add a [GitHub token](https://github.com/settings/tokens) with the `repo` scope. If your organization requires SSO, authorize the token for SSO. 
 4. Confirm that the `workflows` directory has all of the workflow files you want in it
-5. Run `./Create-ActionsPRs.ps1` to install the script. 
+5. Run `Import-Module ./Create-ActionsPRs.ps1` to install the script. 
 6. Run `CreatePullRequestForRepositories -Repositories (GetReposFromOrganization -Organization orgname) -CommitMessage "message" -PRBody "prbody" -BranchName "branch_name"` 
 
 This will create PRs in every repository that you have push permisisons in. 
@@ -22,7 +22,7 @@ This will create PRs in every repository that you have push permisisons in.
 1. Clone this repository to your local machine
 2. Open powershell and navigate to the directory you cloned this into 
 3. Confirm that you have all the workflow files you want in the `workflows` directory
-4. Run `./Create-ActionsPRs.ps1` to install the script. 
+4. Run `Import-Module ./Create-ActionsPRs.ps1` to install the script. 
 5. Create a file with a list of repository URLs, with one repository per line. Save it somewhere you can access. 
 6. Confirm that the `workflows` directory has all of the workflow files you want in it
 7. Run `CreatePullRequestsFromFile -FileName file.txt -CommitMessage "message" -PRBody "prbody" -BranchName "branch_name"`. Replace file.txt with the path to your file, and update the CommitMessage and PRBody as appropriate. 
@@ -32,4 +32,5 @@ This will create PRs in every repository that you have push permisisons in.
 2. Open powershell and navigate to the directory you cloned this into 
 3. Rename the file called `.env-example` to `.env` and add a [GitHub token](https://github.com/settings/tokens) with the `repo` scope. If your organization requires SSO, authorize the token for SSO. 
 4. Confirm that the `workflows` directory has all of the workflow files you want in it; the CodeQL workflow file is already included in this repo
-5. Run `CreatePullRequestsForCodeQLLanguages -Organization orgname` with the organization you want to target instead of orgname. You may optionally override the commit message or PR body by adding `-CommitMessage` or `-PRBody` as appropriate.
+5. Run `Import-Module ./Create-ActionsPRs.ps1` to install the script. 
+6. Run `CreatePullRequestsForCodeQLLanguages -Organization orgname` with the organization you want to target instead of orgname. You may optionally override the commit message or PR body by adding `-CommitMessage` or `-PRBody` as appropriate.

--- a/README.md
+++ b/README.md
@@ -32,5 +32,6 @@ This will create PRs in every repository that you have push permisisons in.
 2. Open powershell and navigate to the directory you cloned this into 
 3. Rename the file called `.env-example` to `.env` and add a [GitHub token](https://github.com/settings/tokens) with the `repo` scope. If your organization requires SSO, authorize the token for SSO. 
 4. Confirm that the `workflows` directory has all of the workflow files you want in it; the CodeQL workflow file is already included in this repo
-5. Run `Import-Module ./Create-ActionsPRs.ps1` to install the script. 
-6. Run `CreatePullRequestsForCodeQLLanguages -Organization orgname` with the organization you want to target instead of orgname. You may optionally override the commit message or PR body by adding `-CommitMessage` or `-PRBody` as appropriate.
+5. If running on Windows, ensure that your `ExecutionPolicy` is set to allow you to run scripts  by opening Powershell as an admin and running `Set-ExecutionPolicy Bypass`
+6. Run `Import-Module ./Create-ActionsPRs.ps1` to install the script. 
+7. Run `CreatePullRequestsForCodeQLLanguages -Organization orgname` with the organization you want to target instead of orgname. You may optionally override the commit message or PR body by adding `-CommitMessage` or `-PRBody` as appropriate.


### PR DESCRIPTION
Just tried this on PowerShell 7 and it wasn't working for me - running `./Create-ActionsPRs.ps1` didn't install any functions. A quick Google search revealed [this StackOverflow post](https://stackoverflow.com/a/36758913) that shows you must either use `.` to source it or `Import-Module`. I tried both of these and they both worked - I was able to tab-complete the rest of the function.

My setup: PowerShell 7.0.3 on Mac OS X Catalina 10.15.7