### PR TITLE
gh pr create shows an interactive menu

### DIFF
--- a/Create-ActionsPRs.ps1
+++ b/Create-ActionsPRs.ps1
@@ -27,6 +27,7 @@ function CreatePullRequestsFromFile {
     copy-item "$PSScriptRoot/workflows" -destination ".github/" -Recurse
     git add -A
     git commit -a -m $CommitMessage
+    git push -u origin $BranchName
     gh pr create -b $PRBody -t $CommitMessage
     Set-Location ../..
     rm -rf $repo_nwo
@@ -54,6 +55,7 @@ function CreatePullRequestForRepositories {
     copy-item "$PSScriptRoot/workflows" -Destination ".github/" -Recurse
     git add -A
     git commit -a -m $CommitMessage
+    git push -u origin $BranchName
     gh pr create -b $PRBody -t $CommitMessage
   }
 }


### PR DESCRIPTION
Avoid the interactive menu by preceeding PR create with `git push -u origin $BranchName`