### PR TITLE
Mbaluda patch

### DIFF
--- a/Create-ActionsPRs.ps1
+++ b/Create-ActionsPRs.ps1
@@ -27,6 +27,7 @@ function CreatePullRequestsFromFile {
     copy-item "$PSScriptRoot/workflows" -destination ".github/" -Recurse
     git add -A
     git commit -a -m $CommitMessage
+    git push -u origin $BranchName
     gh pr create -b $PRBody -t $CommitMessage
     Set-Location ../..
     rm -rf $repo_nwo
@@ -54,6 +55,7 @@ function CreatePullRequestForRepositories {
     copy-item "$PSScriptRoot/workflows" -Destination ".github/" -Recurse
     git add -A
     git commit -a -m $CommitMessage
+    git push -u origin $BranchName
     gh pr create -b $PRBody -t $CommitMessage
   }
 }

--- a/Create-ActionsPRs.ps1
+++ b/Create-ActionsPRs.ps1
@@ -1,50 +1,46 @@
-
 function CreatePullRequestsFromFile {
   param (
-      [string]
-      $FileName,
-      [string] $CommitMessage,
-      [string] $PRBody,
-      [string] $BranchName
+    [string] $FileName,
+    [string] $CommitMessage,
+    [string] $PRBody,
+    [string] $BranchName
   )
   $repos = Get-Content $FileName
 
   # Clone repos
-  foreach ($repo in $repos) 
-  {
+  foreach ($repo in $repos) {
     Set-Location $PSScriptRoot
-    $chunks = $repo.split("/")
-    $repo_nwo = $chunks[3] + "/" + $chunks[4]
+    $chunks = $repo.split("`t")
+    $repo_nwo = $chunks[0]
     gh repo clone $repo_nwo $repo_nwo
     Set-Location $repo_nwo
     git checkout -b $BranchName
     if ((Get-ChildItem .github -ErrorAction SilentlyContinue).Count -eq 0) {
       mkdir .github
     }
-    if ((Get-ChildItem .github/workflows -ErrorAction SilentlyContinue).Count  -eq 0) {
+    if ((Get-ChildItem .github/workflows -ErrorAction SilentlyContinue).Count -eq 0) {
       mkdir .github/workflows
     }
-    copy-item "$PSScriptRoot/workflows" -destination ".github/" -Recurse
+    copy-item "$PSScriptRoot/workflows" -destination ".github/workflows" -Recurse
     git add -A
     git commit -a -m $CommitMessage
     git push -u origin $BranchName
     gh pr create -b $PRBody -t $CommitMessage
     Set-Location ../..
-    rm -rf $repo_nwo
+    Remove-Item -Recurse -Force $repo_nwo
   }
   Set-Location $PSScriptRoot
 }
 
 function CreatePullRequestForRepositories {
   param (
-      # An Array of Repository objects as returned by the GitHub API
-      [array] $Repositories,
-      [string] $CommitMessage,
-      [string] $PRBody,
-      [string] $BranchName
+    # An Array of Repository objects as returned by the GitHub API
+    [array] $Repositories,
+    [string] $CommitMessage,
+    [string] $PRBody,
+    [string] $BranchName
   )
-  foreach ($repo in $repos) 
-  {
+  foreach ($repo in $repos) {
     Set-Location $PSScriptRoot
 
     gh repo clone $repo.full_name $repo.full_name
@@ -52,12 +48,14 @@ function CreatePullRequestForRepositories {
     Set-Location $repo.full_name
     git checkout -b $BranchName
 
-    copy-item "$PSScriptRoot/workflows" -Destination ".github/" -Recurse
+    copy-item "$PSScriptRoot/workflows" -Destination ".github/workflows" -Recurse
     git add -A
     git commit -a -m $CommitMessage
-    git push -u origin $BranchName
     gh pr create -b $PRBody -t $CommitMessage
+    Set-Location ../..
+    Remove-Item -Recurse -Force $repo_nwo
   }
+  Set-Location $PSScriptRoot
 }
 
 function getAuthenticationToken {
@@ -77,13 +75,13 @@ function getHeaders {
   $token = getAuthenticationToken
   $authheader = "Bearer " + $token
   $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-  $headers.Add("Authorization",$authheader)
+  $headers.Add("Authorization", $authheader)
   return $headers
 }
   
 function GetReposFromOrganization {
   param (
-      [string] $Organization
+    [string] $Organization
   )
   $url = "https://api.github.com/orgs/$Organization/repos"
   $headers = getHeaders
@@ -141,13 +139,11 @@ function ContainsAny {
 
 function CreatePullRequestsForCodeQLLanguages {
   param (
-      [string] $Organization,
-      [string] $CommitMessage = "Add CodeQL Analysis workflow",
-      [string] $PRBody = "Adds an Actions workflow which enables CodeQL analysis and will perform static analysis security testing on your code. You'll see results show up in pull requests and/or the Security tab. "
+    [string] $Organization,
+    [string] $CommitMessage = "Add CodeQL Analysis workflow",
+    [string] $PRBody = "Adds an Actions workflow which enables CodeQL analysis and will perform static analysis security testing on your code. You'll see results show up in pull requests and/or the Security tab. "
   )
   $repos = FilterForSupportedLanguages(GetReposFromOrganization -Organization $Organization);
 
   CreatePullRequestForRepositories -Repositories $repos -CommitMessage $CommitMessage -PRBody $PRBody -BranchName codeql
-
 }
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Create-ActionsPRs
-The script in this repository creates pull requests to push a GitHub Actions workflow to multiple repositories. 
+This repository creates pull requests to push a GitHub Actions workflow to a collection of workflows. 
 
 ### Prerequisites
 * Install [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7)
@@ -13,7 +13,7 @@ The script in this repository creates pull requests to push a GitHub Actions wor
 2. Open powershell and navigate to the directory you cloned this into 
 3. Rename the file called `.env-example` to `.env` and add a [GitHub token](https://github.com/settings/tokens) with the `repo` scope. If your organization requires SSO, authorize the token for SSO. 
 4. Confirm that the `workflows` directory has all of the workflow files you want in it
-5. Run `./Create-ActionsPRs.ps1` to install the script. 
+5. Run `Import-Module ./Create-ActionsPRs.ps1` to install the script. 
 6. Run `CreatePullRequestForRepositories -Repositories (GetReposFromOrganization -Organization orgname) -CommitMessage "message" -PRBody "prbody" -BranchName "branch_name"` 
 
 This will create PRs in every repository that you have push permisisons in. 
@@ -22,8 +22,8 @@ This will create PRs in every repository that you have push permisisons in.
 1. Clone this repository to your local machine
 2. Open powershell and navigate to the directory you cloned this into 
 3. Confirm that you have all the workflow files you want in the `workflows` directory
-4. Run `./Create-ActionsPRs.ps1` to install the script. 
-5. Create a file with a list of repository URLs, with one repository per line. Save it somewhere you can access. 
+4. Run `Import-Module ./Create-ActionsPRs.ps1` to install the script. 
+5. Create a file with a list of repository URLs, with one repository per line. Save it somewhere you can access. You can use `gh repo list orgname`
 6. Confirm that the `workflows` directory has all of the workflow files you want in it
 7. Run `CreatePullRequestsFromFile -FileName file.txt -CommitMessage "message" -PRBody "prbody" -BranchName "branch_name"`. Replace file.txt with the path to your file, and update the CommitMessage and PRBody as appropriate. 
 
@@ -32,4 +32,6 @@ This will create PRs in every repository that you have push permisisons in.
 2. Open powershell and navigate to the directory you cloned this into 
 3. Rename the file called `.env-example` to `.env` and add a [GitHub token](https://github.com/settings/tokens) with the `repo` scope. If your organization requires SSO, authorize the token for SSO. 
 4. Confirm that the `workflows` directory has all of the workflow files you want in it; the CodeQL workflow file is already included in this repo
-5. Run `CreatePullRequestsForCodeQLLanguages -Organization orgname` with the organization you want to target instead of orgname. You may optionally override the commit message or PR body by adding `-CommitMessage` or `-PRBody` as appropriate.
+5. If running on Windows, ensure that your `ExecutionPolicy` is set to allow you to run scripts  by opening Powershell as an admin and running `Set-ExecutionPolicy Bypass`
+6. Run `Import-Module ./Create-ActionsPRs.ps1` to install the script. 
+7. Run `CreatePullRequestsForCodeQLLanguages -Organization orgname` with the organization you want to target instead of orgname. You may optionally override the commit message or PR body by adding `-CommitMessage` or `-PRBody` as appropriate.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This will create PRs in every repository that you have push permisisons in.
 2. Open powershell and navigate to the directory you cloned this into 
 3. Confirm that you have all the workflow files you want in the `workflows` directory
 4. Run `Import-Module ./Create-ActionsPRs.ps1` to install the script. 
-5. Create a file with a list of repository URLs, with one repository per line. Save it somewhere you can access. You can use `gh repo list orgname`
+5. Create a file with a list of repositories, one `org/repo` entry per line. Save it somewhere you can access. You can use `gh repo list orgname`
 6. Confirm that the `workflows` directory has all of the workflow files you want in it
 7. Run `CreatePullRequestsFromFile -FileName file.txt -CommitMessage "message" -PRBody "prbody" -BranchName "branch_name"`. Replace file.txt with the path to your file, and update the CommitMessage and PRBody as appropriate. 
 


### PR DESCRIPTION
- replace `rm` with `Remove-Item` for compatibility
- add a call to `git push` before `gh pr create` to avoid the request for interactive input
- the expected file format is now compatible with the output of `gh repo list orgname`
- adapted the documentation
